### PR TITLE
ISSUE:7121 - warning when try to create multiple products with the same SKU (product duplication improvement and test)

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/Sku.php
@@ -11,6 +11,7 @@
  *
  * @author     Magento Core Team <core@magentocommerce.com>
  */
+
 namespace Magento\Catalog\Model\Product\Attribute\Backend;
 
 use Magento\Catalog\Model\Product;
@@ -44,6 +45,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Validate SKU
      *
      * @param Product $object
+     *
      * @return bool
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\LocalizedException
@@ -53,7 +55,9 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
         $attrCode = $this->getAttribute()->getAttributeCode();
         $value = $object->getData($attrCode);
         if ($this->getAttribute()->getIsRequired() && strlen($value) === 0) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('The value of attribute "%1" must be set', $attrCode));
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('The value of attribute "%1" must be set', $attrCode)
+            );
         }
 
         if ($this->string->strlen($object->getSku()) > self::SKU_MAX_LENGTH) {
@@ -61,6 +65,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
                 __('SKU length should be %1 characters maximum.', self::SKU_MAX_LENGTH)
             );
         }
+
         return true;
     }
 
@@ -68,7 +73,10 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Check unique SKU for product
      *
      * @param Product $object
+     *
      * @return void
+     *
+     * @throws AlreadyExistsException
      */
     private function checkUniqueSku($object)
     {
@@ -82,7 +90,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
                     'Duplicated %attribute found: %value',
                     [
                         'attribute' => $attributeCode,
-                        'value' => $attributeValue
+                        'value' => $attributeValue,
                     ]
                 )
             );
@@ -93,8 +101,8 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Generate and set unique SKU to product
      *
      * @param Product $object
+     *
      * @return void
-     * @deprecated
      */
     protected function _generateUniqueSku($object)
     {
@@ -119,11 +127,17 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      * Make SKU unique before save
      *
      * @param Product $object
+     *
      * @return $this
      */
     public function beforeSave($object)
     {
-        $this->checkUniqueSku($object);
+        if (true === $object->getIsDuplicate()) {
+            $this->_generateUniqueSku($object);
+        } else {
+            $this->checkUniqueSku($object);
+        }
+
         return parent::beforeSave($object);
     }
 
@@ -132,6 +146,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
      *
      * @param \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $attribute
      * @param Product $object
+     *
      * @return int
      * @deprecated
      */
@@ -153,6 +168,7 @@ class Sku extends \Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend
             1
         );
         $data = $connection->fetchOne($select, $bind);
-        return abs((int)str_replace($value, '', $data));
+
+        return abs((int) str_replace($value, '', $data));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Backend/SkuTest.php
@@ -3,10 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Catalog\Model\Product\Attribute\Backend;
 
 /**
  * Test class for \Magento\Catalog\Model\Product\Attribute\Backend\Sku.
+ *
  * @magentoAppArea adminhtml
  */
 class SkuTest extends \PHPUnit\Framework\TestCase
@@ -14,7 +16,28 @@ class SkuTest extends \PHPUnit\Framework\TestCase
     /**
      * @magentoDataFixture Magento/Catalog/_files/product_simple.php
      */
-    public function testGenerateUniqueSkuExistingProduct()
+    public function testGenerateUniqueSkuDuplicatedProduct()
+    {
+        $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\ProductRepository::class
+        );
+        $product = $repository->get('simple');
+        /** @var \Magento\Catalog\Model\Product\Copier $copier */
+        $copier = $this->getCopier();
+        /** @var \Magento\Catalog\Model\Product; $product2 */
+        $product2 = $copier->copy($product);
+
+        $this->assertEquals('simple', $product->getSku());
+        $product2->getResource()->getAttribute('sku')->getBackend()->beforeSave($product2);
+        $this->assertEquals('simple-1', $product2->getSku());
+    }
+
+    /**
+     * Checks if generation of unique sku is not allowed
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     */
+    public function testPreventGenerateUniqueSkuExistingProduct()
     {
         $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\ProductRepository::class
@@ -22,12 +45,16 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         $product = $repository->get('simple');
         $product->setId(null);
         $this->assertEquals('simple', $product->getSku());
+
+        $this->expectException('Magento\Framework\Exception\AlreadyExistsException');
         $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('simple-1', $product->getSku());
+
+        $this->fail('Unique sku generation should be allowed only for product duplication.');
     }
 
     /**
      * @param $product \Magento\Catalog\Model\Product
+     *
      * @dataProvider uniqueSkuDataProvider
      */
     public function testGenerateUniqueSkuNotExistingProduct($product)
@@ -42,7 +69,38 @@ class SkuTest extends \PHPUnit\Framework\TestCase
      * @magentoAppArea adminhtml
      * @magentoDbIsolation enabled
      */
-    public function testGenerateUniqueLongSku()
+    public function testGenerateUniqueLongSkuDuplicatedProduct()
+    {
+        $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
+            \Magento\Catalog\Model\ProductRepository::class
+        );
+        $product = $repository->get('simple');
+        $product->setSku('0123456789012345678901234567890123456789012345678901234567890124');
+        $product->save();
+        $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
+        $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890124', $product->getSku());
+
+        /** @var \Magento\Catalog\Model\Product\Copier $copier */
+        $copier = $this->getCopier();
+        $product2 = $copier->copy($product);
+
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product2->getSku());
+        $product2->getResource()->getAttribute('sku')->getBackend()->beforeSave($product2);
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product2->getSku());
+
+        $product2->setId(null);
+        $product2->getResource()->getAttribute('sku')->getBackend()->beforeSave($product2);
+        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-2', $product2->getSku());
+    }
+
+    /**
+     * Checks if generation of long unique sku is not allowed
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoAppArea adminhtml
+     * @magentoDbIsolation enabled
+     */
+    public function testPreventGenerateUniqueLongSku()
     {
         $repository = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
             \Magento\Catalog\Model\ProductRepository::class
@@ -51,13 +109,14 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         $product->setSku('0123456789012345678901234567890123456789012345678901234567890123');
 
         /** @var \Magento\Catalog\Model\Product\Copier $copier */
-        $copier = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Catalog\Model\Product\Copier::class
-        );
+        $copier = $this->getCopier();
+
         $copier->copy($product);
         $this->assertEquals('0123456789012345678901234567890123456789012345678901234567890123', $product->getSku());
+        $this->expectException('Magento\Framework\Exception\AlreadyExistsException');
         $product->getResource()->getAttribute('sku')->getBackend()->beforeSave($product);
-        $this->assertEquals('01234567890123456789012345678901234567890123456789012345678901-1', $product->getSku());
+
+        $this->fail('Unique long sku generation should be allowed only for product duplication.');
     }
 
     /**
@@ -68,6 +127,7 @@ class SkuTest extends \PHPUnit\Framework\TestCase
     public function uniqueSkuDataProvider()
     {
         $product = $this->_getProduct();
+
         return [[$product]];
     }
 
@@ -107,6 +167,18 @@ class SkuTest extends \PHPUnit\Framework\TestCase
         )->setStockData(
             ['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1]
         );
+
         return $product;
     }
+
+    /**
+     * @return \Magento\Catalog\Model\Product\Copier
+     */
+    protected function getCopier()
+    {
+        return \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
+            \Magento\Catalog\Model\Product\Copier::class
+        );
+    }
+
 }


### PR DESCRIPTION
ISSUE:7121 - warning when try to create multiple products with the same SKU (Improvement for product duplication and integration tests)

### Description
- Improvement for product duplication for admin area, when saving the product by choosing: Save & Duplicate
- Adding a product with the same sku is still not allowed
- Fixes in integration tests

### Manual testing scenarios
1. Choose Save & duplicate in admin product edit form. Product should be successfully saved and an edit form with the duplicated product data should be opened (previously it was not possible because of an exception about duplicated sku)
2. Try to add product with already existing product sku (via admin area or api). An exception should be thrown with message about duplicated sku.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
